### PR TITLE
Fix -NaN return value bug for track eta component

### DIFF
--- a/AMSimulationDataFormats/interface/TTTrack2.h
+++ b/AMSimulationDataFormats/interface/TTTrack2.h
@@ -103,7 +103,7 @@ class TTTrack2 {
 
     float pt(float B=3.8)                       const { return std::abs(0.003 * B / rinv()); }  // assume r is in cm, B is in Tesla
     float invPt(float B=3.8)                    const { return rinv() / (0.003 * B); }          // assume r is in cm, B is in Tesla
-    float theta()                               const { return std::atan(1.0 / cottheta()); }
+    float theta()                               const { return std::atan2(1.0, cottheta()); }
     float eta()                                 const { return -std::log(tan(theta()/2.0)); }
     float phi()                                 const { return phi0(); }
     float px()                                  const { return pt() * std::cos(phi0()); }


### PR DESCRIPTION
std::atan is an unsafe function around values of 0. The recommended replacement is std::atan2, which is implemented in this changed file.
