### PR TITLE
parameter-based duplicate removal inclusion

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -113,6 +113,9 @@ int main(int argc, char **argv) {
 
 	// Only for Duplicate Flag
         ("rmDuplicate", po::value<int>(&option.rmDuplicate)->default_value(-1), "Duplicate removal option. The argument is the number of max stubs allowed to be shared between AM tracks")
+
+	// Only for parameter-based duplicate removal
+	("rmParDuplicate", po::value<bool>(&option.rmParDuplicate)->default_value(false), "Parameter-based duplicate removal switch")
 	
         // Only for NTupleMaker
         ("no-trim"      , po::bool_switch(&option.no_trim)->default_value(false), "Do not trim ntuple branches")

--- a/AMSimulation/interface/ParameterDuplicateRemoval.h
+++ b/AMSimulation/interface/ParameterDuplicateRemoval.h
@@ -1,0 +1,54 @@
+#ifndef AMSimulation_ParameterDuplicateRemoval_h_
+#define AMSimulation_ParameterDuplicateRemoval_h_
+
+#include "SLHCL1TrackTriggerSimulations/AMSimulationIO/interface/TTTrackReader.h"
+#include <vector>
+
+namespace slhcl1tt{
+  class ParameterDuplicateRemoval{
+    public:
+      ParameterDuplicateRemoval() {}
+      ~ParameterDuplicateRemoval() {}
+
+      void ReduceTracks(std::vector<TTTrack2>& Tracks);
+  };
+
+  //structure containing necessary original Track information
+  struct TrackCloud{
+    std::vector<unsigned> TrackIterators;
+    unsigned  BestTrack;
+    bool BestRoadCategory; //false = 5/x, true = 6/6
+    float BestChi2;
+    float BestEta;
+    float BestPhi;
+
+    bool Add(unsigned TrackIterator_, const std::vector<unsigned> &combination_, float Chi2_, float Eta_, float Phi_){
+      bool ContainsNoDummy=true;
+      for(unsigned i=0; i<combination_.size(); ++i){
+        if(combination_[i]==999999999) ContainsNoDummy=false;
+      }
+      if(TrackIterators.size()==0){
+        TrackIterators.push_back(TrackIterator_);
+        BestChi2=Chi2_;
+        BestEta=Eta_;
+        BestPhi=Phi_;
+        BestRoadCategory=ContainsNoDummy;
+        BestTrack=TrackIterator_;
+        return true;
+      }
+      else if(fabs(Eta_-BestEta)<0.0601 && fabs(Phi_-BestPhi)<0.00576){
+        if(Chi2_<BestChi2){    
+          BestChi2=Chi2_;
+          BestEta=Eta_;
+          BestPhi=Phi_;
+	  BestTrack=TrackIterator_;
+        }
+        TrackIterators.push_back(TrackIterator_);
+        return true;
+      }
+      else return false;
+    }
+  };
+}
+
+#endif

--- a/AMSimulation/interface/ParameterDuplicateRemoval.h
+++ b/AMSimulation/interface/ParameterDuplicateRemoval.h
@@ -3,6 +3,7 @@
 
 #include "SLHCL1TrackTriggerSimulations/AMSimulationIO/interface/TTTrackReader.h"
 #include <vector>
+#include <TVector2.h>
 
 namespace slhcl1tt{
   class ParameterDuplicateRemoval{
@@ -36,11 +37,12 @@ namespace slhcl1tt{
         BestTrack=TrackIterator_;
         return true;
       }
-      else if(fabs(Eta_-BestEta)<0.0601 && fabs(Phi_-BestPhi)<0.00576){
+      else if(fabs(Eta_-BestEta)<0.0601 && fabs(TVector2::Phi_mpi_pi(Phi_-BestPhi))<0.00576){
         if(Chi2_<BestChi2){    
           BestChi2=Chi2_;
           BestEta=Eta_;
           BestPhi=Phi_;
+	  BestRoadCategory=ContainsNoDummy;
 	  BestTrack=TrackIterator_;
         }
         TrackIterators.push_back(TrackIterator_);

--- a/AMSimulation/interface/ProgramOption.h
+++ b/AMSimulation/interface/ProgramOption.h
@@ -54,6 +54,7 @@ struct ProgramOption {
     int         maxTracks;
 
     int 	rmDuplicate;
+    bool        rmParDuplicate;
 
     bool        no_trim;
     bool        removeOverlap;

--- a/AMSimulation/interface/TrackFitter.h
+++ b/AMSimulation/interface/TrackFitter.h
@@ -9,6 +9,7 @@
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/CombinationFactory.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/GhostBuster.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/DuplicateRemoval.h"
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/ParameterDuplicateRemoval.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/MCTruthAssociator.h"
 using namespace slhcl1tt;
 

--- a/AMSimulation/src/ParameterDuplicateRemoval.cc
+++ b/AMSimulation/src/ParameterDuplicateRemoval.cc
@@ -1,0 +1,35 @@
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/ParameterDuplicateRemoval.h"
+using namespace slhcl1tt;
+
+void ParameterDuplicateRemoval::ReduceTracks(std::vector<TTTrack2>& Tracks){
+  std::vector<TrackCloud> Clouds; //container for merged tracks
+  for(unsigned t=0; t<Tracks.size(); ++t){
+    if(Clouds.size()==0){ //start a new cloud, if there isn't any, yet
+      TrackCloud element;
+      Clouds.push_back(element);
+      Clouds[0].Add(t,Tracks.at(t).stubRefs(),Tracks.at(t).chi2()/Tracks.at(t).ndof(),Tracks.at(t).eta(),Tracks.at(t).phi0());
+    }
+    else{
+      bool FoundCloud=false;
+      for(unsigned c=0; c<Clouds.size(); ++c){
+	FoundCloud=Clouds[c].Add(t,Tracks.at(t).stubRefs(),Tracks.at(t).chi2()/Tracks.at(t).ndof(),Tracks.at(t).eta(),Tracks.at(t).phi0());
+	if(FoundCloud) break;
+      }//end cloud loop
+      if(!FoundCloud){
+	TrackCloud element;
+	Clouds.push_back(element);
+	Clouds[Clouds.size()-1].Add(t,Tracks.at(t).stubRefs(),Tracks.at(t).chi2()/Tracks.at(t).ndof(),Tracks.at(t).eta(),Tracks.at(t).phi0());
+      }
+    }
+  }//end track loop
+
+  //new track collection of unique tracks
+  std::vector<TTTrack2> UniqueTracks;
+  for(unsigned c=0; c<Clouds.size(); ++c){
+    UniqueTracks.push_back(Tracks.at(Clouds[c].BestTrack));
+  }//end cloud loop 2
+  
+  Tracks.resize(UniqueTracks.size());
+  Tracks=UniqueTracks;
+  assert(Tracks.size() == UniqueTracks.size());
+}

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -210,6 +210,13 @@ int TrackFitter::makeTracks(TString src, TString out) {
 	DuplicateRemoval flagDuplicates;
 	flagDuplicates.CheckTracks(tracks, po_.rmDuplicate);
 
+	//----------------------------------------------------------------------
+	// Identify and flag duplicates by defining a track-parameter space 
+	// inside of which anything is considered to be a single track
+	//----------------------------------------------------------------------
+	ParameterDuplicateRemoval RemoveParameterDuplicates;
+	if(po_.rmParDuplicate) RemoveParameterDuplicates.ReduceTracks(tracks);
+
 
 
 


### PR DESCRIPTION
Hi Sergo,
here's my addition of the parameter-based duplicate removal as a subroutine.
The tag for activating it is:
--rmParDuplicate 1
It's containing 1 working point we think works well for different samples and otherwise its compiling and seems to be doing its job, so it ought to be ready to go.
Cheers,
Denis
