### PR TITLE
5/6 permutations for 6/6 combinations & pairwise DeltaDeltaS cleaning

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -115,7 +115,11 @@ int main(int argc, char **argv) {
         ("rmDuplicate", po::value<int>(&option.rmDuplicate)->default_value(-1), "Duplicate removal option. The argument is the number of max stubs allowed to be shared between AM tracks")
 
 	// Only for parameter-based duplicate removal
-	("rmParDuplicate", po::value<bool>(&option.rmParDuplicate)->default_value(false), "Parameter-based duplicate removal switch")
+	("rmParDuplicate", po::bool_switch(&option.rmParDuplicate)->default_value(false), "Parameter-based duplicate removal switch")
+
+	//Only for alternative combination builder configuration
+	("FiveOfSix", po::bool_switch(&option.FiveOfSix)->default_value(false), "Do all 5/6 permutations of 6/6 roads in addition")
+	("PDDS", po::bool_switch(&option.PDDS)->default_value(false), "Switch on pairwise Delta Delta S combination cleaning")
 	
         // Only for NTupleMaker
         ("no-trim"      , po::bool_switch(&option.no_trim)->default_value(false), "Do not trim ntuple branches")

--- a/AMSimulation/interface/PairCombinationFactory.h
+++ b/AMSimulation/interface/PairCombinationFactory.h
@@ -1,0 +1,39 @@
+#ifndef AMSimulation_PairCombinationFactory_h_
+#define AMSimulation_PairCombinationFactory_h_
+
+#include <vector>
+#include <iostream>
+#include <cmath>
+#include "SLHCL1TrackTriggerSimulations/AMSimulationDataFormats/interface/PairAssignment.h"
+
+namespace slhcl1tt{
+
+class PairCombinationFactory{
+  public:
+    PairCombinationFactory() : verbose_(true) {}
+    
+    ~PairCombinationFactory() {}
+    
+    // Enum
+    enum Flag { BAD=999999999 };
+    
+    std::vector<std::vector<unsigned> > combine(const std::vector<std::vector<unsigned> >& groups, std::vector<std::vector<float> > DeltaS, bool FiveOfSix);
+    
+    //debug
+    void print();
+    
+  private:
+    int verbose_;
+    
+    //DDS value coarsening based on layer number
+    float Coarsener(float DeltaS, int precision, int layer);
+
+    //central functions
+    std::vector<PairAssignment> Stage1Pair(std::vector<std::pair<unsigned, float> > first, std::vector<std::pair<unsigned, float> > second, float cut);
+    std::vector<std::vector<unsigned> > CombinationBuilder(std::vector<PairAssignment> Layer10, std::vector<PairAssignment> Layer12, std::vector<PairAssignment> Layer32, std::vector<PairAssignment> Layer34, std::vector<PairAssignment> Layer54, unsigned l0, unsigned l2, unsigned l4);
+};
+
+    
+}
+
+#endif

--- a/AMSimulation/interface/ProgramOption.h
+++ b/AMSimulation/interface/ProgramOption.h
@@ -56,6 +56,9 @@ struct ProgramOption {
     int 	rmDuplicate;
     bool        rmParDuplicate;
 
+    bool	FiveOfSix;
+    bool	PDDS;
+
     bool        no_trim;
     bool        removeOverlap;
 

--- a/AMSimulation/interface/TrackFitter.h
+++ b/AMSimulation/interface/TrackFitter.h
@@ -7,6 +7,7 @@
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TrackFitterAlgoATF.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TrackFitterAlgoLTF.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/CombinationFactory.h"
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/PairCombinationFactory.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/GhostBuster.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/DuplicateRemoval.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/ParameterDuplicateRemoval.h"
@@ -66,6 +67,9 @@ class TrackFitter {
 
     // Combination factory
     CombinationFactory combinationFactory_;
+    
+    // pair combination factory
+    PairCombinationFactory pairCombinationFactory_;
 
     // Ghost buster
     GhostBuster ghostBuster_;

--- a/AMSimulation/src/PairCombinationFactory.cc
+++ b/AMSimulation/src/PairCombinationFactory.cc
@@ -1,0 +1,102 @@
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/PairCombinationFactory.h"
+using namespace slhcl1tt;
+
+#include <iostream>
+
+float PairCombinationFactory::Coarsener(float DeltaS, int precision, int layer){ //maximum precision is 4, minimum 2
+  float Coarsed=0.;
+  if(layer<3) Coarsed = DeltaS-((int)(2*DeltaS)%(int)pow(2,3-(precision-1)))/2.;
+  else        Coarsed = DeltaS-((int)(2*DeltaS)%(int)pow(2,4-precision))/2.;
+  return Coarsed;
+}
+
+std::vector<PairAssignment> PairCombinationFactory::Stage1Pair(std::vector<std::pair<unsigned, float> > first, std::vector<std::pair<unsigned, float> > second, float cut)
+{  
+  //initialize pair assignment struct, loop and filter pairs
+  std::vector<PairAssignment> PairedOnes;
+  for(unsigned i=0; i<first.size(); ++i){
+    for(unsigned j=0; j<second.size(); ++j){
+      bool Survivor=true;
+      if(first[i].first==PairCombinationFactory::BAD && second[j].first==PairCombinationFactory::BAD) Survivor=false; //catch double dummy cases
+      else if(fabs(first[i].second-second[j].second)>cut && !(first[i].first==PairCombinationFactory::BAD || second[j].first==PairCombinationFactory::BAD) ) Survivor=false; //pairwise DDS cut, spares any pair with only a single dummy
+      PairedOnes.push_back(PairAssignment(first[i].first,second[j].first,Survivor));
+    }
+  }
+  //give back assignment map
+  return PairedOnes;
+}
+
+//combination(stubAddresses,pass)
+std::vector<std::vector<unsigned> > PairCombinationFactory::CombinationBuilder(std::vector<PairAssignment> Layer10, std::vector<PairAssignment> Layer12, std::vector<PairAssignment> Layer32, std::vector<PairAssignment> Layer34, std::vector<PairAssignment> Layer54, unsigned l0, unsigned l2, unsigned l4)
+{
+  //initialize return object
+  std::vector<std::vector<unsigned> >  Combinations;
+  //loop over all permutations
+  for(unsigned i=0; i<Layer10.size(); ++i){
+    for(unsigned j=0; j<Layer32.size(); ++j){
+      for(unsigned k=0; k<Layer54.size(); ++k){
+	if(!(Layer10[i].SurvivingPair * Layer32[j].SurvivingPair * Layer54[k].SurvivingPair)) continue; //3-logic part
+	//5-logic stub position lookup
+	int pos12=i/l0*l2+j%l2;
+	int pos34=j/l2*l4+k%l4;
+	if(!(Layer12[pos12].SurvivingPair * Layer34[pos34].SurvivingPair)) continue; //5-logic extension
+	std::vector<unsigned> layers={Layer10[i].Stub2Address, Layer10[i].Stub1Address, Layer32[j].Stub2Address, Layer32[j].Stub1Address, Layer54[k].Stub2Address, Layer54[k].Stub1Address};
+
+	//catch >1 dummy cases, always put dummy in the first position per layer!
+	unsigned dummyCounter=0;
+	for(unsigned l=0; l<layers.size(); ++l) if(layers[l]==PairCombinationFactory::BAD) ++dummyCounter;
+	if(dummyCounter>1) continue;
+
+	//build combination object
+	Combinations.push_back(layers);
+      }
+    }
+  }
+  return Combinations;
+}
+
+std::vector<std::vector<unsigned> > PairCombinationFactory::combine(const std::vector<std::vector<unsigned> >& groups, std::vector<std::vector<float> > DeltaS, bool FiveOfSix) {
+        std::vector<std::vector<unsigned> > combinations;
+        std::vector<std::vector<unsigned> > CombinationBase=groups;
+
+        unsigned ngroups = groups.size(); //number of layers
+	std::vector<std::vector<std::pair<unsigned, float> > > Layer; //0 is innermost, 5 is outermost
+
+	//check for empty layers, add 1 dummy to nonempty layers
+	for(unsigned i=0; i<ngroups; ++i){
+	  if(!CombinationBase[i].size()){
+	    CombinationBase[i].push_back(PairCombinationFactory::BAD);
+	    DeltaS[i].push_back(999.);
+	  }
+	  else if(FiveOfSix){
+	    CombinationBase[i].insert(CombinationBase[i].begin(),PairCombinationFactory::BAD); //only insert dummies in full layers, if 5/6 permutations are desired
+	    DeltaS[i].insert(DeltaS[i].begin(),999.);
+	  }
+	}
+
+	if(ngroups!=6) return combinations; //catch less than 6 layers present
+	for(unsigned layer=0; layer<6; ++layer){ //compose all the layer information
+	  std::vector<std::pair<unsigned, float> > OneLayer;
+	  Layer.push_back(OneLayer);
+	  for(unsigned j=0; j<CombinationBase[layer].size(); ++j) Layer[layer].push_back(std::make_pair(CombinationBase[layer][j], Coarsener(DeltaS[layer][j],4,layer))); //pushes back stub iterator and coarsened DeltaS value
+	}
+	
+	//build layer pairs & pass cut values
+	std::vector<PairAssignment> Layer01=Stage1Pair(Layer[1],Layer[0],1.5);
+	std::vector<PairAssignment> Layer12=Stage1Pair(Layer[1],Layer[2],2.5);
+	std::vector<PairAssignment> Layer23=Stage1Pair(Layer[3],Layer[2],3.0);
+	std::vector<PairAssignment> Layer34=Stage1Pair(Layer[3],Layer[4],2.0);
+	std::vector<PairAssignment> Layer45=Stage1Pair(Layer[5],Layer[4],2.0);
+
+	//build the actual combinations
+	combinations = CombinationBuilder(Layer01,Layer12,Layer23,Layer34,Layer45,CombinationBase[0].size(),CombinationBase[2].size(),CombinationBase[4].size());
+	//for(unsigned c=0; c<combinations.size(); ++c) std::cout<<combinations[c][0]<<","<<combinations[c][1]<<","<<combinations[c][2]<<","<<combinations[c][3]<<","<<combinations[c][4]<<","<<combinations[c][5]<<std::endl;  //combination verbose
+        return combinations;
+}
+
+// _____________________________________________________________________________
+void PairCombinationFactory::print() {
+    std::cout << std::endl;
+}
+
+

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -97,12 +97,22 @@ int TrackFitter::makeTracks(TString src, TString out) {
 
             // Get combinations of stubRefs
             std::vector<std::vector<unsigned> > stubRefs = reader.vr_stubRefs->at(iroad);
+	    std::vector<std::vector<float> > stubDeltaS; //pass DeltaS information for each stub to the PDDS
             for (unsigned ilayer=0; ilayer<stubRefs.size(); ++ilayer) {
-                if (stubRefs.at(ilayer).size() > (unsigned) po_.maxStubs)
+	        std::vector<float> placeholderTemp;
+	        stubDeltaS.push_back(placeholderTemp);
+		if(po_.PDDS) for(unsigned istub=0; istub<stubRefs[ilayer].size(); ++istub) stubDeltaS[ilayer].push_back(reader.vb_trigBend->at(stubRefs[ilayer][istub]));
+		else for(unsigned istub=0; istub<stubRefs[ilayer].size(); ++istub) stubDeltaS[ilayer].push_back(0.); //default DDS is 0 to disable PDDS cleaning
+                if (stubRefs.at(ilayer).size() > (unsigned) po_.maxStubs){
                     stubRefs.at(ilayer).resize(po_.maxStubs);
+		    stubDeltaS.at(ilayer).resize(po_.maxStubs);
+		}
             }
-
-            const std::vector<std::vector<unsigned> >& combinations = combinationFactory_.combine(stubRefs);
+	    
+	    //choose either the normal combination building or the 5/6 permutations per 6/6 road in addition and/or pairwise Delta Delta S cleaning (PDDS)
+	    std::vector<std::vector<unsigned> > combinations;
+            if(po_.FiveOfSix || po_.PDDS)	combinations = pairCombinationFactory_.combine(stubRefs, stubDeltaS, po_.FiveOfSix);
+	    else 				combinations = combinationFactory_.combine(stubRefs);			
 
             for (unsigned icomb=0; icomb<combinations.size(); ++icomb)
                 assert(combinations.at(icomb).size() == reader.vr_stubRefs->at(iroad).size());

--- a/AMSimulation/src/TrackFitterAlgoLTF.cc
+++ b/AMSimulation/src/TrackFitterAlgoLTF.cc
@@ -11,7 +11,7 @@ int TrackFitterAlgoLTF::fit(const TTRoadComb& acomb, TTTrack2& atrack) {
     }
 
     double normChi2 = linearizedTrackFitter_->fit(vars, acomb.hitBits);
-    std::cout<<" chi2="<<normChi2<<"\n";
+    //std::cout<<" chi2="<<normChi2<<"\n";
     const std::vector<double>& pars = linearizedTrackFitter_->estimatedPars();
     //const std::vector<double>& principals = linearizedTrackFitter_->principalComponents();
     const std::vector<double>& principals = linearizedTrackFitter_->normalizedPrincipalComponents();

--- a/AMSimulationDataFormats/interface/PairAssignment.h
+++ b/AMSimulationDataFormats/interface/PairAssignment.h
@@ -1,0 +1,20 @@
+#ifndef AMSimulationDataFormats_PairAssignment_h_
+#define AMSimulationDataFormats_PairAssignment_h_
+
+namespace slhcl1tt{
+
+struct PairAssignment //structure for saving pairs for the pairwise Delta Delta S combination cleanup
+{
+  unsigned Stub1Address;
+  unsigned Stub2Address;
+  bool SurvivingPair;
+  PairAssignment(unsigned Stub1Address_, unsigned Stub2Address_, bool SurvivingPair_){
+    Stub1Address=Stub1Address_;
+    Stub2Address=Stub2Address_;
+    SurvivingPair=SurvivingPair_;
+  }
+};
+
+}
+
+#endif


### PR DESCRIPTION
Hi Sergo,
I added my other work, including an alternate combination builder that can do all 5/6 permutations of any 6/6 combination without repetititons (activate by --FiveOfSix ) and the pairwise Delta Delta S cleaning (activate by --PDDS) . If you want to, you can do both at the same time.
The default continues to be the normal combination builder.
Moreover, I changed --rmParDuplicate to a bool switch, so it doesn't need any arguments anymore.
Finally, I commented a stray cout out that somehow made it into the TrackFitterAlgoLTF file and spammed everything with chi2 values.
Cheers,
Denis
