### PR TITLE
Add LocalToGlobal [2] -- 	add 'emu' option, and perform LocalToGlobalMap consistently

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
 
         ("verbosity,v"  , po::value<int>(&option.verbose)->default_value(1), "Verbosity level (-1 = very quiet; 0 = quiet, 1 = verbose, 2+ = debug)")
         ("speedup"      , po::value<int>(&option.speedup)->default_value(0), "Speed-up level")
+        ("emu"          , po::value<int>(&option.emu)->default_value(0), "Emulation version")
         ("maxEvents,n"  , po::value<long long>(&option.maxEvents)->default_value(-1), "Specfiy max number of events")
 
         ("nLayers"      , po::value<unsigned>(&option.nLayers)->default_value(6), "Specify # of layers")

--- a/AMSimulation/interface/PatternMatcher.h
+++ b/AMSimulation/interface/PatternMatcher.h
@@ -5,6 +5,7 @@
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/Helper.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/ProgramOption.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TriggerTowerMap.h"
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/LocalToGlobalMap.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/SuperstripArbiter.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/AssociativeMemory.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/HitBuffer.h"
@@ -24,6 +25,9 @@ class PatternMatcher {
         ttmap_ = new TriggerTowerMap();
         ttmap_->read(po_.datadir);
 
+        l2gmap_ = new LocalToGlobalMap();
+        l2gmap_->read(po_.datadir);
+
         arbiter_ = new SuperstripArbiter();
         arbiter_->setDefinition(po_.superstrip, po_.tower, ttmap_);
 
@@ -36,6 +40,7 @@ class PatternMatcher {
     // Destructor
     ~PatternMatcher() {
         if (ttmap_)     delete ttmap_;
+        if (l2gmap_)    delete l2gmap_;
         if (arbiter_)   delete arbiter_;
     }
 
@@ -64,6 +69,7 @@ class PatternMatcher {
 
     // Operators
     TriggerTowerMap   * ttmap_;
+    LocalToGlobalMap  * l2gmap_;
     SuperstripArbiter * arbiter_;
     ModuleOverlapMap  * momap_;
 

--- a/AMSimulation/interface/ProgramOption.h
+++ b/AMSimulation/interface/ProgramOption.h
@@ -17,6 +17,7 @@ struct ProgramOption {
 
     int         verbose;
     int         speedup;
+    int         emu;
     long long   maxEvents;
 
     unsigned    nLayers;

--- a/AMSimulation/interface/TrackFitter.h
+++ b/AMSimulation/interface/TrackFitter.h
@@ -3,6 +3,7 @@
 
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/Helper.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/ProgramOption.h"
+#include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/LocalToGlobalMap.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TrackFitterAlgoPCA.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TrackFitterAlgoATF.h"
 #include "SLHCL1TrackTriggerSimulations/AMSimulation/interface/TrackFitterAlgoLTF.h"
@@ -23,6 +24,9 @@ class TrackFitter {
       nEvents_(po.maxEvents), verbose_(po.verbose),
       prefixRoad_("AMTTRoads_"), prefixTrack_("AMTTTracks_"), suffix_("") {
 
+        l2gmap_ = new LocalToGlobalMap();
+        l2gmap_->read(po_.datadir);
+
         // Decide the track fitter to use
         fitter_ = 0;
         if (po.algo == "PCA4" || po.algo == "PCA5") {
@@ -40,6 +44,7 @@ class TrackFitter {
 
     // Destructor
     ~TrackFitter() {
+        if (l2gmap_)  delete l2gmap_;
         if (fitter_)  delete fitter_;
     }
 
@@ -60,6 +65,9 @@ class TrackFitter {
     const TString prefixRoad_;
     const TString prefixTrack_;
     const TString suffix_;
+
+    // Operators
+    LocalToGlobalMap  * l2gmap_;
 
     // Track fitter
     TrackFitterAlgoBase *  fitter_;

--- a/AMSimulation/src/PatternGenerator.cc
+++ b/AMSimulation/src/PatternGenerator.cc
@@ -115,10 +115,6 @@ int PatternGenerator::makePatterns(TString src) {
 
             // Do local-to-global conversion
             l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
-            //std::cout << "moduleId: " << moduleId << " strip: " << strip << " segment: " << segment << std::endl;
-            //std::cout << "r  : " << stub_r   << " conv: " << conv_r   << std::endl;
-            //std::cout << "phi: " << stub_phi << " conv: " << conv_phi << std::endl;
-            //std::cout << "z  : " << stub_z   << " conv: " << conv_z   << std::endl;
 
             // Find superstrip ID
             unsigned ssId = 0;
@@ -126,8 +122,11 @@ int PatternGenerator::makePatterns(TString src) {
                 ssId = arbiter_ -> superstripLocal(moduleId, strip, segment);
 
             } else {                              // global coordinates
-                //ssId = arbiter_ -> superstripGlobal(moduleId, stub_r, stub_phi, stub_z, stub_ds);
-                ssId = arbiter_ -> superstripLocal(moduleId, strip, segment, conv_l2g);
+                if (po_.emu == 0) {
+                    ssId = arbiter_ -> superstripGlobal(moduleId, stub_r, stub_phi, stub_z, stub_ds);
+                } else {
+                    ssId = arbiter_ -> superstripLocal(moduleId, strip, segment, conv_l2g);
+                }
             }
             patt.at(istub) = ssId;
 

--- a/AMSimulation/src/ProgramOption.cc
+++ b/AMSimulation/src/ProgramOption.cc
@@ -24,6 +24,7 @@ std::ostream& operator<<(std::ostream& o, const ProgramOption& po) {
 
       << "  verbose: "      << po.verbose
       << "  speedup: "      << po.speedup
+      << "  emu: "          << po.emu
       << "  maxEvents: "    << po.maxEvents
 
       << "  nLayers: "      << po.nLayers

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -128,13 +128,25 @@ int TrackFitter::makeTracks(TString src, TString out) {
                 acomb.stubs_z   .clear();
                 acomb.stubs_bool.clear();
 
+                float conv_r = 0., conv_phi = 0., conv_z = 0.;
+                LocalToGlobal conv_l2g;
+
                 for (unsigned istub=0; istub<acomb.stubRefs.size(); ++istub) {
                     const unsigned stubRef = acomb.stubRefs.at(istub);
                     if (stubRef != CombinationFactory::BAD) {
-                        acomb.stubs_r   .push_back(reader.vb_r   ->at(stubRef));
-                        acomb.stubs_phi .push_back(reader.vb_phi ->at(stubRef));
-                        acomb.stubs_z   .push_back(reader.vb_z   ->at(stubRef));
-                        acomb.stubs_bool.push_back(true);
+                        if (po_.emu == 0) {
+                            acomb.stubs_r   .push_back(reader.vb_r   ->at(stubRef));
+                            acomb.stubs_phi .push_back(reader.vb_phi ->at(stubRef));
+                            acomb.stubs_z   .push_back(reader.vb_z   ->at(stubRef));
+                            acomb.stubs_bool.push_back(true);
+                        } else {
+                            // Do local-to-global conversion
+                            l2gmap_ -> convert(reader.vb_modId->at(stubRef), reader.vb_coordx->at(stubRef), reader.vb_coordy->at(stubRef), conv_r, conv_phi, conv_z, conv_l2g);
+                            acomb.stubs_r   .push_back(conv_r);
+                            acomb.stubs_phi .push_back(conv_phi);
+                            acomb.stubs_z   .push_back(conv_z);
+                            acomb.stubs_bool.push_back(true);
+                        }
                     } else {
                         acomb.stubs_r   .push_back(0.);
                         acomb.stubs_phi .push_back(0.);


### PR DESCRIPTION
This commit is a continuation of pull #5 to add LocalToGlobal coordinate conversion to the 'demo2016' branch.

'amsim' gains an integer option 'emu'. emu == 0 is without LocalToGlobal coordinate conversion emulation. emu > 0 turns on the emulation.

LocalToGlobalMap is now also inserted into PatternMatcher and TrackFitter, in addition to PatternGenerator.
