### PR TITLE
Modify TTRoadComb

### DIFF
--- a/AMSimulation/src/LocalToGlobalMap.cc
+++ b/AMSimulation/src/LocalToGlobalMap.cc
@@ -192,6 +192,17 @@ void LocalToGlobalMap::convertInt(const unsigned moduleId, const float strip, co
             conv_r   >>= 1;
         }
     }
+
+    // Store only 18 LSBs, signed
+    conv_phi  &= 0x3ffff;
+    conv_z    &= 0x3ffff;
+    conv_r    &= 0x3ffff;
+
+    // Pad with left 1s if negative
+    conv_phi  |= (conv_phi  & 0x20000) ? 0xfffffffffffc0000 : 0;
+    conv_z    |= (conv_z    & 0x20000) ? 0xfffffffffffc0000 : 0;
+    conv_r    |= (conv_r    & 0x20000) ? 0xfffffffffffc0000 : 0;
+
     return;
 }
 

--- a/AMSimulationDataFormats/interface/TTRoadComb.h
+++ b/AMSimulationDataFormats/interface/TTRoadComb.h
@@ -19,6 +19,7 @@ struct TTRoadComb {
     std::vector<float> stubs_phi;
     std::vector<float> stubs_z;
     std::vector<bool>  stubs_bool;
+    std::vector<std::string> stubs_bitString;
 };
 
 


### PR DESCRIPTION
This commit modifies TTRoadComb to add a member 'stubs_bitString', which is a std::string that holds the 66 bits for every stub (after AM) going to the track fitter emulator which Marco will interface
   1 bit for data_valid (in simulation we can just set it to 1 for every stub)
   18 bits for phi with range of plus/minus 1 radian
   18 bits for R  with range of plus/minus 1024 cm
   18 bits for z with  range of plus/minus 1024 cm
   4 bits for stub bend info
   7 bits for the strip ID within the module for radial conversion.

| 65..65 | 64..47 | 46..29 | 28..11 | 10..7 | 6..0 |
| --- | --- | --- | --- | --- | --- |
| unsigned 1b | signed 18b | signed 18b | signed 18b | signed 4b | unsigned 7b |
| data_valid | phi | r | z | bend (4 MSB) | moduleId (7 MSB) |

The bit string is built in the TrackFitter class. Please verify the order of the bits is correct before merging this pull request.

Also, 18-bit masking is now applied in the results from LocalToGlobalMap convertInt().
