### PR TITLE
Add additional TTStubs branches in TTRoadWriter and TTRoadReader

### DIFF
--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -33,6 +33,19 @@ unsigned getHitBits(const std::vector<bool>& stubs_bool) {
 bool sortByPt(const TTTrack2& lhs, const TTTrack2& rhs) {
     return lhs.pt() > rhs.pt();
 }
+
+template<int N, int S>  // N=number of bits, S=signed or unsigned
+struct MyBitSet {
+    int64_t operator()(const std::string& bitString, size_t pos=0, size_t n=N) {
+        std::bitset<N> bits(bitString, pos, n);
+        int64_t ret = static_cast<int64_t>(bits.to_ulong());
+        if (S>0 && bits.test(N-1)) {  // is signed and is negative
+            static const uint64_t ffffffff = -1;
+            ret |= (ffffffff << N);
+        }
+        return ret;
+    }
+};
 }
 
 
@@ -149,38 +162,44 @@ int TrackFitter::makeTracks(TString src, TString out) {
                             acomb.stubs_bool.push_back(true);
                             acomb.stubs_bitString.push_back("");
                         } else {
-                            // Do local-to-global conversion
-                            unsigned moduleId = reader.vb_modId   ->at(istub);
-                            float    strip    = reader.vb_coordx  ->at(istub);  // in full-strip unit
-                            float    segment  = reader.vb_coordy  ->at(istub);  // in full-strip unit
-                            float    bend     = reader.vb_trigBend->at(istub);  // in full-strip unit
-                            l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
-                            l2gmap_ -> convertInt(moduleId, strip, segment, po_.tower, conv_l2g, conv_r_int, conv_phi_int, conv_z_int, conv_l2g_int);
-
-                            acomb.stubs_r   .push_back(conv_r);
-                            acomb.stubs_phi .push_back(conv_phi);
-                            acomb.stubs_z   .push_back(conv_z);
+                            acomb.stubs_r   .push_back(reader.vb_r   ->at(stubRef));  // full floating-point precision, not fixed-point precion
+                            acomb.stubs_phi .push_back(reader.vb_phi ->at(stubRef));  // full floating-point precision, not fixed-point precion
+                            acomb.stubs_z   .push_back(reader.vb_z   ->at(stubRef));  // full floating-point precision, not fixed-point precion
                             acomb.stubs_bool.push_back(true);
+                            acomb.stubs_bitString.push_back(reader.vb_bitString->at(stubRef));
 
-                            // All together this is a 66 bit string for every stub (after AM) going to the track fitter 
-                            // emulator which Marco will interface
-                            //   1 bit for data_valid (in simulation we can just set it to 1 for every stub)
-                            //   18 bits for phi with range of plus/minus 1 radian
-                            //   18 bits for R  with range of plus/minus 1024 cm
-                            //   18 bits for z with  range of plus/minus 1024 cm
-                            //   4 bits for stub bend info
-                            //   7 bits for the strip ID within the module for radial conversion.
-                            int bend_4b = int(std::round(bend)) >> 1;
-                            int strip_7b = (halfStripRound(strip)) >> 4;
+                            // This block is safe to remove
+                            {
+                                // Do local-to-global conversion
+                                unsigned moduleId = reader.vb_modId   ->at(stubRef);
+                                float    strip    = reader.vb_coordx  ->at(stubRef);  // in full-strip unit
+                                float    segment  = reader.vb_coordy  ->at(stubRef);  // in full-strip unit
+                                float    stub_ds  = reader.vb_trigBend->at(stubRef);  // in full-strip unit
+                                l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
+                                l2gmap_ -> convertInt(moduleId, strip, segment, po_.tower, conv_l2g, conv_r_int, conv_phi_int, conv_z_int, conv_l2g_int);
 
-                            std::string bitString = "";
-                            bitString += std::bitset<1>(int(1)).to_string();
-                            bitString += std::bitset<18>(conv_phi_int).to_string();
-                            bitString += std::bitset<18>(conv_r_int).to_string();
-                            bitString += std::bitset<18>(conv_z_int).to_string();
-                            bitString += std::bitset<4>(bend_4b).to_string();
-                            bitString += std::bitset<7>(strip_7b).to_string();
-                            acomb.stubs_bitString.push_back(bitString);
+                                int bend_4b = int(std::round(stub_ds)) >> 1;
+                                int strip_7b = (halfStripRound(strip)) >> 4;
+
+                                // Sanity checks
+                                const std::string& bitString = acomb.stubs_bitString.back();
+                                int64_t conv_phi_int_2 = MyBitSet<18,1>()(bitString, 1);  // 18 bits starting from position 1
+                                int64_t conv_r_int_2   = MyBitSet<18,1>()(bitString, 1+18);
+                                int64_t conv_z_int_2   = MyBitSet<18,1>()(bitString, 1+18+18);
+                                int64_t bend_4b_2      = MyBitSet<4,1> ()(bitString, 1+18+18+18);
+                                int64_t strip_7b_2     = MyBitSet<7,0> ()(bitString, 1+18+18+18+4);
+
+                                assert(conv_phi_int_2 == conv_phi_int);
+                                assert(conv_r_int_2   == conv_r_int);
+                                assert(conv_z_int_2   == conv_z_int);
+                                assert(bend_4b_2      == bend_4b);
+                                assert(strip_7b_2     == strip_7b);
+                                assert(bitString.size() == 66);
+
+                                const unsigned superstripId = reader.vr_superstripIds->at(iroad).at(istub);
+                                const unsigned superstripId2 = reader.vb_superstripId->at(stubRef);
+                                assert(superstripId2 == superstripId);
+                            }
                         }
                     } else {
                         acomb.stubs_r   .push_back(0.);

--- a/AMSimulationIO/interface/TTRoadReader.h
+++ b/AMSimulationIO/interface/TTRoadReader.h
@@ -15,6 +15,12 @@ class TTRoadReader : public TTStubPlusTPReader {
 
     int init(TString src, TString prefix, TString suffix);
 
+    // Stubs
+    // Adding stubs branches here is inconsistent and ugly, but changing
+    // TTStubReader is problematic now and breaks backward compatibility
+    std::vector<std::string> *                          vb_bitString;
+    std::vector<unsigned> *                             vb_superstripId;
+
     // Roads
     std::vector<unsigned> *                             vr_patternRef;
     std::vector<unsigned> *                             vr_tower;
@@ -35,7 +41,15 @@ class TTRoadWriter : public BasicWriter {
 
     void fill(const std::vector<TTRoad>& roads);
 
+    void fill(const std::vector<TTRoad>& roads, const std::vector<std::string>& stubs_bitString, const std::vector<unsigned>& stubs_superstripId);
+
   protected:
+    // Stubs
+    // Adding stubs branches here is inconsistent and ugly, but changing
+    // TTStubReader is problematic now and breaks backward compatibility
+    std::auto_ptr<std::vector<std::string> >                          vb_bitString;
+    std::auto_ptr<std::vector<unsigned> >                             vb_superstripId;
+
     // Roads
     std::auto_ptr<std::vector<unsigned> >                             vr_patternRef;
     std::auto_ptr<std::vector<unsigned> >                             vr_tower;

--- a/AMSimulationIO/src/TTRoadReader.cc
+++ b/AMSimulationIO/src/TTRoadReader.cc
@@ -8,6 +8,9 @@ using namespace slhcl1tt;
 TTRoadReader::TTRoadReader(int verbose)
 : TTStubPlusTPReader(verbose),
 
+  vb_bitString    (0),
+  vb_superstripId (0),
+
   vr_patternRef   (0),
   vr_tower        (0),
   vr_nstubs       (0),
@@ -22,6 +25,10 @@ int TTRoadReader::init(TString src, TString prefix, TString suffix) {
         return 1;
 
     // Set branch addresses
+    TString prefixStub = "TTStubs_", suffixStub = "";
+    tchain->SetBranchAddress(prefixStub + "bitString"     + suffixStub, &(vb_bitString));
+    tchain->SetBranchAddress(prefixStub + "superstripId"  + suffixStub, &(vb_superstripId));
+
     tchain->SetBranchAddress(prefix + "patternRef"    + suffix, &(vr_patternRef));
     tchain->SetBranchAddress(prefix + "tower"         + suffix, &(vr_tower));
     tchain->SetBranchAddress(prefix + "nstubs"        + suffix, &(vr_nstubs));
@@ -36,6 +43,9 @@ int TTRoadReader::init(TString src, TString prefix, TString suffix) {
 TTRoadWriter::TTRoadWriter(int verbose)
 : BasicWriter(verbose),
 
+  vb_bitString      (new std::vector<std::string>()),
+  vb_superstripId   (new std::vector<unsigned>()),
+
   vr_patternRef     (new std::vector<unsigned>()),
   vr_tower          (new std::vector<unsigned>()),
   vr_nstubs         (new std::vector<unsigned>()),
@@ -48,6 +58,10 @@ TTRoadWriter::~TTRoadWriter() {}
 int TTRoadWriter::init(TChain* tchain, TString out, TString prefix, TString suffix) {
     if (BasicWriter::init(tchain, out))
         return 1;
+
+    TString prefixStub = "TTStubs_", suffixStub = "";
+    ttree->Branch(prefixStub + "bitString"     + suffixStub, &(*vb_bitString));
+    ttree->Branch(prefixStub + "superstripId"  + suffixStub, &(*vb_superstripId));
 
     ttree->Branch(prefix + "patternRef"    + suffix, &(*vr_patternRef));
     ttree->Branch(prefix + "tower"         + suffix, &(*vr_tower));
@@ -79,4 +93,11 @@ void TTRoadWriter::fill(const std::vector<TTRoad>& roads) {
 
     ttree->Fill();
     assert(vr_patternRef->size() == nroads);
+}
+
+void TTRoadWriter::fill(const std::vector<TTRoad>& roads, const std::vector<std::string>& stubs_bitString, const std::vector<unsigned>& stubs_superstripId) {
+    *vb_bitString = stubs_bitString;
+    *vb_superstripId = stubs_superstripId;
+
+    fill(roads);
 }


### PR DESCRIPTION
As the title says, this adds additional TTStubs branches to be written into the output "roads.root". It's really not elegant, but whatever works... The new branches are "TTStubs_bitString" and "TTStubs_superstrip". They are implemented in the fashion suggested by Luciano, i.e. they are associated by stub, instead of by road or by combination. An example to get the bitString would be:

```
for each iroad:
    for each isuperstrip:
        for each istub:
            stubRef := TTRoads_stubRefs[iroad][isuperstrip][istub]
            bitString := TTStubs_bitString[stubRef]
```

The bitString is now constructed in the PatternMatcher module now. Previously, the bitString was constructed in the TrackFitter module when building a TTRoadComb.  Now it's directly read from "roads.root".

I also included a nice struct that converts bitString to 64-bit signed integers. C++ only let you convert to unsigned integers. (Though, my struct will (silently) fail if the bitString length is less than the number of bits requested, so use with care).

The block of codes from lines 171-202 is safe to remove. It is only there for sanity checks. I left it there as it might help others to check how to parse the bitString as intended.
https://github.com/jiafulow/SLHCL1TrackTriggerSimulations/blob/b9f2aed665/AMSimulation/src/TrackFitter.cc#L171-L202

I tested with ~2000 events and did some sanity checks. Everything seems to work. :)
