### PR TITLE
Apply cut of max 4 stubs per superstrip

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         // Only for pattern matching
         ("maxPatterns"  , po::value<long int>(&option.maxPatterns)->default_value(999999999), "Specfiy max number of patterns")
         ("maxMisses"    , po::value<int>(&option.maxMisses)->default_value(0), "Specify max number of allowed misses")
-        ("maxStubs"     , po::value<int>(&option.maxStubs)->default_value(999999999), "Specfiy max number of stubs per superstrip")
+        ("maxStubs"     , po::value<int>(&option.maxStubs)->default_value(4), "Specfiy max number of stubs per superstrip")
         ("maxRoads"     , po::value<int>(&option.maxRoads)->default_value(999999999), "Specfiy max number of roads per event")
 
         // Only for matrix building

--- a/AMSimulation/src/HitBuffer.cc
+++ b/AMSimulation/src/HitBuffer.cc
@@ -12,6 +12,7 @@ int HitBuffer::init(unsigned maxBins) {
 
     superstripBools_.clear();
     superstripBools_.resize(maxBins);
+    assert(superstripBools_.size() != 0);
 
     return 0;
 }
@@ -34,11 +35,16 @@ void HitBuffer::insert(superstrip_type ss, unsigned stubRef) {
 void HitBuffer::freeze(unsigned maxStubs) {
     for (std::map<superstrip_type, std::vector<unsigned> >::iterator it=superstripHits_.begin();
          it!=superstripHits_.end(); ++it) {
-        if (it->second.size() > maxStubs)
-            it->second.resize(maxStubs);
+
+        if (it->second.size() > maxStubs) {
+            //it->second.resize(maxStubs);  // keep first N stubs
+
+            std::vector<unsigned> tmp(it->second.end()-maxStubs, it->second.end());  // keep last N stubs
+            assert(tmp.size() == maxStubs);
+            it->second = tmp;
+        }
     }
 
-    assert(superstripBools_.size() != 0);
     frozen_ = true;
 }
 

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -111,10 +111,10 @@ int TrackFitter::makeTracks(TString src, TString out) {
 
             // Get combinations of stubRefs
             std::vector<std::vector<unsigned> > stubRefs = reader.vr_stubRefs->at(iroad);
-            for (unsigned ilayer=0; ilayer<stubRefs.size(); ++ilayer) {
-                if (stubRefs.at(ilayer).size() > (unsigned) po_.maxStubs)
-                    stubRefs.at(ilayer).resize(po_.maxStubs);
-            }
+            //for (unsigned ilayer=0; ilayer<stubRefs.size(); ++ilayer) {
+            //    if (stubRefs.at(ilayer).size() > (unsigned) po_.maxStubs)
+            //        stubRefs.at(ilayer).resize(po_.maxStubs);
+            //}
 
 	    // const std::vector<std::vector<unsigned> > & combinations = combinationFactory_.combine(stubRefs);
 


### PR DESCRIPTION
This fixes the action item of moving the 4 stubs per superstrip limit from CB to Data Organizer/Hit Buffer. It involves two (minor) changes:
- Set default "maxStubs" to "4"
- Keep the last N="maxStubs" stubs in the HitBuffer class
