### PR TITLE
Principal Cuts

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -107,6 +107,7 @@ int main(int argc, char **argv) {
 
         // Only for track fitting
         ("maxChi2"      , po::value<float>(&option.maxChi2)->default_value(5.), "Specify maximum reduced chi-squared")
+	("CutPrincipals", po::bool_switch(&option.CutPrincipals)->default_value(false), "replace chi**2 cut with principals cut")
         ("minNdof"      , po::value<int>(&option.minNdof)->default_value(1), "Specify minimum degree of freedom")
         ("maxCombs"     , po::value<int>(&option.maxCombs)->default_value(999999999), "Specfiy max number of combinations per road")
         ("maxTracks"    , po::value<int>(&option.maxTracks)->default_value(999999999), "Specfiy max number of tracks per event")

--- a/AMSimulation/interface/ParameterDuplicateRemoval.h
+++ b/AMSimulation/interface/ParameterDuplicateRemoval.h
@@ -22,8 +22,9 @@ namespace slhcl1tt{
     float BestChi2;
     float BestEta;
     float BestPhi;
+    float BestPt; //test
 
-    bool Add(unsigned TrackIterator_, const std::vector<unsigned> &combination_, float Chi2_, float Eta_, float Phi_){
+    bool Add(unsigned TrackIterator_, const std::vector<unsigned> &combination_, float Chi2_, float Eta_, float Phi_, float Pt_){ //test
       bool ContainsNoDummy=true;
       for(unsigned i=0; i<combination_.size(); ++i){
         if(combination_[i]==999999999) ContainsNoDummy=false;
@@ -33,15 +34,17 @@ namespace slhcl1tt{
         BestChi2=Chi2_;
         BestEta=Eta_;
         BestPhi=Phi_;
+        BestPt=Pt_; //test
         BestRoadCategory=ContainsNoDummy;
         BestTrack=TrackIterator_;
         return true;
       }
-      else if(fabs(Eta_-BestEta)<0.0601 && fabs(TVector2::Phi_mpi_pi(Phi_-BestPhi))<0.00576){
+      else if(fabs(Eta_-BestEta)<0.0601 && fabs(TVector2::Phi_mpi_pi(Phi_-BestPhi))<0.00576 && ((BestPt>100. && Pt_>100.) || fabs(BestPt-Pt_)<10.)){ //test
         if(Chi2_<BestChi2){    
           BestChi2=Chi2_;
           BestEta=Eta_;
           BestPhi=Phi_;
+	  BestPt=Pt_; //test
 	  BestRoadCategory=ContainsNoDummy;
 	  BestTrack=TrackIterator_;
         }

--- a/AMSimulation/interface/ProgramOption.h
+++ b/AMSimulation/interface/ProgramOption.h
@@ -49,6 +49,7 @@ struct ProgramOption {
     unsigned    hitBits;
 
     float       maxChi2;
+    bool	CutPrincipals;
     int         minNdof;
     int         maxCombs;
     int         maxTracks;

--- a/AMSimulation/src/ProgramOption.cc
+++ b/AMSimulation/src/ProgramOption.cc
@@ -56,6 +56,7 @@ std::ostream& operator<<(std::ostream& o, const ProgramOption& po) {
       << "  hitBits: "      << po.hitBits
 
       << "  maxChi2: "      << po.maxChi2
+      << "  CutPrincipals: "<< po.CutPrincipals
       << "  minNdof: "      << po.minNdof
       << "  maxCombs: "     << po.maxCombs
       << "  maxTracks: "    << po.maxTracks

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -32,6 +32,28 @@ unsigned getHitBits(const std::vector<bool>& stubs_bool) {
 bool sortByPt(const TTTrack2& lhs, const TTTrack2& rhs) {
     return lhs.pt() > rhs.pt();
 }
+
+// principal component cut function
+bool PrincipalCuts(std::vector<float> princes){
+  bool pass=true;
+  const float Cuts6[12]={58.,33.,22.,12.,-1.,-1.,9.,3.,3.,3.,-1.,-1.};
+  const float Cuts5[10]={33.,22.,12.,-1.,-1.,3.,3.,3.,-1.,-1.};
+  if(princes.size()==12) for(unsigned i=0; i<princes.size(); ++i){
+    if(Cuts6[i]==-1) continue;
+    if(fabs(princes[i])>Cuts6[i]){
+      pass=false;
+      break;
+    }
+  }
+  else for(unsigned i=0; i<princes.size(); ++i){
+    if(Cuts5[i]==-1) continue;
+    if(fabs(princes[i])>Cuts5[i]){
+      pass=false;
+      break;
+    }
+  }
+  return pass;
+}
 }
 
 
@@ -173,8 +195,11 @@ int TrackFitter::makeTracks(TString src, TString out) {
                 atrack.setHitBits   (acomb.hitBits);
                 atrack.setStubRefs  (acomb.stubRefs);
 
-                if (atrack.chi2Red() < po_.maxChi2)  // reduced chi^2 = chi^2 / ndof
+                if(!po_.CutPrincipals){
+		  if (atrack.chi2Red() < po_.maxChi2)  // reduced chi^2 = chi^2 / ndof
                     tracks.push_back(atrack);
+		}
+		else if(PrincipalCuts(atrack.principals())) tracks.push_back(atrack);
 
                 if (verbose_>2)  std::cout << Debug() << "... ... ... track: " << icomb << " status: " << fitstatus << " reduced chi2: " << atrack.chi2Red() << " invPt: " << atrack.invPt() << " phi0: " << atrack.phi0() << " cottheta: " << atrack.cottheta() << " z0: " << atrack.z0() << std::endl;
             }


### PR DESCRIPTION
Hi Sergo,
I added an option to cut on principal components instead of chi2, as shown by Jacob on tuesday.
It is activated by the flag --CutPrincipals and replaces the chi2 cut, if activated.
Cheers,
Denis
