### PR TITLE
fix the deltaS encoding bug and add several new branches for demo

### DIFF
--- a/AMSimulation/interface/NTupleMaker.h
+++ b/AMSimulation/interface/NTupleMaker.h
@@ -25,7 +25,7 @@ class NTupleMaker {
         FLOAT_VV , DOUBLE_VV , LONG64_VV , ULONG64_VV , BOOL_VV ,
         CHAR_VVV , UCHAR_VVV , SHORT_VVV , USHORT_VVV , INT_VVV , UINT_VVV,
         FLOAT_VVV, DOUBLE_VVV, LONG64_VVV, ULONG64_VVV, BOOL_VVV,
-        STRING,
+        STRING_V,
         NumLeafTypes
     };
 

--- a/AMSimulation/interface/PatternGenerator.h
+++ b/AMSimulation/interface/PatternGenerator.h
@@ -58,6 +58,9 @@ class PatternGenerator {
     // Write pattern bank
     int writePatterns(TString out);
 
+    // Write pattern bank to a .coe file for firmware
+    int writePatternsEmu(TString out);
+
     // Program options
     const ProgramOption po_;
     long long nEvents_;

--- a/AMSimulation/src/NTupleMaker.cc
+++ b/AMSimulation/src/NTupleMaker.cc
@@ -105,6 +105,8 @@ int NTupleMaker::writeTree(TString out) {
     // For merging
     chain_roads_->SetBranchStatus("*", 0);
     chain_roads_->SetBranchStatus("AMTTRoads_*", 1);
+    chain_roads_->SetBranchStatus("TTStubs_bitString", 1);
+    chain_roads_->SetBranchStatus("TTStubs_superstripId", 1);
     TObjArray* branches_roads = chain_roads_->GetListOfBranches();
     for (int i=0; i<branches_roads->GetEntries(); ++i) {
         TBranch* branch = (TBranch*) branches_roads->At(i);
@@ -192,6 +194,7 @@ void NTupleMaker::makeLeafMap() {
     leafmap["Long64_t"] = LONG64_T;
     leafmap["ULong64_t"] = ULONG64_T;
 
+    leafmap["vector<string>"] = STRING_V;
     leafmap["vector<char>"] = CHAR_V;
     leafmap["vector<unsigned char>"] = UCHAR_V;
     leafmap["vector<short>"] = SHORT_V;
@@ -248,6 +251,7 @@ void NTupleMaker::makeConnector(const TBranch* branch, TTree* tree) {
         case ULONG64_T  : connectors.push_back(new TypedBranchConnector<ULong64_t> (branchName, "l", tree) ); break;
         case BOOL_T     : connectors.push_back(new TypedBranchConnector<Bool_t>    (branchName, "O", tree) ); break;
 
+        case STRING_V   : connectors.push_back(new TypedBranchConnector<std::vector<std::string>>(branchName, "", tree) ); break;
         case CHAR_V     : connectors.push_back(new TypedBranchConnector<std::vector<Char_t> >    (branchName, "", tree) ); break;
         case UCHAR_V    : connectors.push_back(new TypedBranchConnector<std::vector<UChar_t> >   (branchName, "", tree) ); break;
         case SHORT_V    : connectors.push_back(new TypedBranchConnector<std::vector<Short_t> >   (branchName, "", tree) ); break;

--- a/AMSimulation/src/PatternMatcher.cc
+++ b/AMSimulation/src/PatternMatcher.cc
@@ -306,7 +306,7 @@ int PatternMatcher::makeRoads(TString src, TString out) {
                 //   18 bits for z with  range of plus/minus 1024 cm
                 //   4 bits for stub bend info
                 //   7 bits for the strip ID within the module for radial conversion.
-                int bend_4b = int(std::round(stub_ds)) >> 1;
+                int bend_4b = int(std::round(stub_ds));
                 int strip_7b = (halfStripRound(strip)) >> 4;
 
                 std::string bitString = "";

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -167,7 +167,7 @@ int TrackFitter::makeTracks(TString src, TString out) {
                                 l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
                                 l2gmap_ -> convertInt(moduleId, strip, segment, po_.tower, conv_l2g, conv_r_int, conv_phi_int, conv_z_int, conv_l2g_int);
 
-                                int bend_4b = int(std::round(stub_ds)) >> 1;
+                                int bend_4b = int(std::round(stub_ds));
                                 int strip_7b = (halfStripRound(strip)) >> 4;
 
                                 // Sanity checks

--- a/AMSimulationIO/interface/BasicReader.h
+++ b/AMSimulationIO/interface/BasicReader.h
@@ -43,6 +43,7 @@ class BasicReader {
     std::vector<int> *            vp_charge;
 
     // Stub information
+    std::vector<float> *          vb_simPt;
     std::vector<float> *          vb_x;
     std::vector<float> *          vb_y;
     std::vector<float> *          vb_z;

--- a/AMSimulationIO/src/BasicReader.cc
+++ b/AMSimulationIO/src/BasicReader.cc
@@ -14,6 +14,7 @@ BasicReader::BasicReader(int verbose)
   vp_vz               (0),
   vp_charge           (0),
   //
+  vb_simPt            (0),
   vb_x                (0),
   vb_y                (0),
   vb_z                (0),
@@ -72,6 +73,7 @@ int BasicReader::init(TString src, bool full) {
     tchain->SetBranchAddress("genParts_vy"       , &(vp_vy));
     tchain->SetBranchAddress("genParts_vz"       , &(vp_vz));
     tchain->SetBranchAddress("genParts_charge"   , &(vp_charge));
+    tchain->SetBranchAddress("TTStubs_simPt"     , &(vb_simPt));
     if (full)  tchain->SetBranchAddress("TTStubs_x"         , &(vb_x));
     if (full)  tchain->SetBranchAddress("TTStubs_y"         , &(vb_y));
     tchain->SetBranchAddress("TTStubs_z"         , &(vb_z));
@@ -95,6 +97,7 @@ int BasicReader::init(TString src, bool full) {
     tchain->SetBranchStatus("genParts_vy"       , 1);
     tchain->SetBranchStatus("genParts_vz"       , 1);
     tchain->SetBranchStatus("genParts_charge"   , 1);
+    tchain->SetBranchStatus("TTStubs_simPt"     , 1);
     if (full)  tchain->SetBranchStatus("TTStubs_x"         , 1);
     if (full)  tchain->SetBranchStatus("TTStubs_y"         , 1);
     tchain->SetBranchStatus("TTStubs_z"         , 1);
@@ -113,6 +116,7 @@ int BasicReader::init(TString src, bool full) {
 }
 
 void BasicReader::nullStubs(const std::vector<bool>& nulling, bool full) {
+    nullVectorElements(vb_simPt     , nulling);
     if (full)  nullVectorElements(vb_x         , nulling);
     if (full)  nullVectorElements(vb_y         , nulling);
     nullVectorElements(vb_z         , nulling);


### PR DESCRIPTION
The new 4-bits deltaS. Example: 
orig    -2.5   -2     -1.5   -1     -0.5   0      0.5    1      1.5    2      2.5    3      3.5
round   -3     -2     -2     -1     -1     0      1      1      2      2      3      3      4
binary  1101   1110   1110   1111   1111   0000   0001   0001   0010   0010   0011   0011   0100
