### PR TITLE
Demo2016

### DIFF
--- a/AMSimulation/interface/TrackFitter.h
+++ b/AMSimulation/interface/TrackFitter.h
@@ -50,7 +50,7 @@ class TrackFitter {
                 std::cout << "error opening FirmwareInputRoads.txt" << std::endl;
                 return;
             }
-            firmwareOutputFile_.open("FirmwareOutput.txt");
+            firmwareOutputFile_.open("EmulatorOutput.txt");
             if (!firmwareOutputFile_) {
                 std::cout << "error opening FirmwareOutput.txt" << std::endl;
                 return;
@@ -69,7 +69,8 @@ class TrackFitter {
     // Main driver
     int run();
 
-    void writeFirmwareInput(const std::vector<std::vector<unsigned> > & stubRefs, TTRoadReader & reader);
+    void writeFirmwareInput(const std::vector<std::vector<unsigned> > & stubRefs, TTRoadReader & reader,
+                            const long long & ievt);
     void writeFirmwareOutput(const TTTrack2 & atrack);
 
   private:

--- a/AMSimulation/src/PatternMatcher.cc
+++ b/AMSimulation/src/PatternMatcher.cc
@@ -306,7 +306,6 @@ int PatternMatcher::makeRoads(TString src, TString out) {
                 //   18 bits for z with  range of plus/minus 1024 cm
                 //   4 bits for stub bend info
                 //   7 bits for the strip ID within the module for radial conversion.
-                // int bend_4b = int(std::round(stub_ds)) >> 1;
                 int bend_4b = int(std::round(stub_ds));
                 int strip_7b = (halfStripRound(strip)) >> 4;
 

--- a/AMSimulation/src/PatternMatcher.cc
+++ b/AMSimulation/src/PatternMatcher.cc
@@ -306,7 +306,8 @@ int PatternMatcher::makeRoads(TString src, TString out) {
                 //   18 bits for z with  range of plus/minus 1024 cm
                 //   4 bits for stub bend info
                 //   7 bits for the strip ID within the module for radial conversion.
-                int bend_4b = int(std::round(stub_ds)) >> 1;
+                // int bend_4b = int(std::round(stub_ds)) >> 1;
+                int bend_4b = int(std::round(stub_ds));
                 int strip_7b = (halfStripRound(strip)) >> 4;
 
                 std::string bitString = "";

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -167,7 +167,6 @@ int TrackFitter::makeTracks(TString src, TString out) {
                                 l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
                                 l2gmap_ -> convertInt(moduleId, strip, segment, po_.tower, conv_l2g, conv_r_int, conv_phi_int, conv_z_int, conv_l2g_int);
 
-                                // int bend_4b = int(std::round(stub_ds)) >> 1;
                                 int bend_4b = int(std::round(stub_ds));
                                 int strip_7b = (halfStripRound(strip)) >> 4;
 

--- a/AMSimulation/src/TrackFitter.cc
+++ b/AMSimulation/src/TrackFitter.cc
@@ -103,7 +103,7 @@ int TrackFitter::makeTracks(TString src, TString out) {
                     stubRefs.at(ilayer).resize(po_.maxStubs);
             }
 
-            if (po_.emu != 0) writeFirmwareInput(stubRefs, reader);
+            if (po_.emu != 0) writeFirmwareInput(stubRefs, reader, ievt);
 
             // const std::vector<std::vector<unsigned> > & combinations = combinationFactory_.combine(stubRefs);
 
@@ -167,7 +167,8 @@ int TrackFitter::makeTracks(TString src, TString out) {
                                 l2gmap_ -> convert(moduleId, strip, segment, conv_r, conv_phi, conv_z, conv_l2g);
                                 l2gmap_ -> convertInt(moduleId, strip, segment, po_.tower, conv_l2g, conv_r_int, conv_phi_int, conv_z_int, conv_l2g_int);
 
-                                int bend_4b = int(std::round(stub_ds)) >> 1;
+                                // int bend_4b = int(std::round(stub_ds)) >> 1;
+                                int bend_4b = int(std::round(stub_ds));
                                 int strip_7b = (halfStripRound(strip)) >> 4;
 
                                 // Sanity checks
@@ -353,8 +354,11 @@ int TrackFitter::run() {
 }
 
 
-void TrackFitter::writeFirmwareInput(const std::vector<std::vector<unsigned> > & stubRefs, TTRoadReader & reader)
+void TrackFitter::writeFirmwareInput(const std::vector<std::vector<unsigned> > & stubRefs, TTRoadReader & reader,
+                                     const long long & ievt)
 {
+    // Keep track of the event id
+    firmwareInputFile_ << std::setfill('0') << std::setw(5) << ievt << " ";
     unsigned ilayer = 0;
     for (auto layer : stubRefs) {
         // std::cout << "layer " << ilayer << ": ";


### PR DESCRIPTION
Updated format of FirmwareInputRoads.txt to containing the roads in firmware-compatible format to match the output of the DO firmware. Also changed the name of the fitter emulator output file to be compared to the fitter firmware output from FirmwareOutput.txt to EmulatorOutput.txt for better clarity.
