### PR TITLE
write LUT to .coe files for firmware

### DIFF
--- a/AMSimulation/src/LUTGenerator.cc
+++ b/AMSimulation/src/LUTGenerator.cc
@@ -16,7 +16,7 @@ unsigned LUTGenerator::localModuleId(unsigned moduleId) {
 
     unsigned lad = decodeLadder(moduleId);
     unsigned mod = decodeModule(moduleId);
-    unsigned newModuleId = ((lad & 0xf) << 4) | (mod & 0xf);
+    unsigned newModuleId = ((mod & 0x1f) << 4) | (lad & 0xf);
 
     return newModuleId;
 }
@@ -61,7 +61,7 @@ int LUTGenerator::makeLocalToGlobal() {
             bitString += std::bitset<18>(conv_l2g_int.i_phi).to_string();
             bitString += std::bitset<18>(conv_l2g_int.i_z0).to_string();
             bitString += std::bitset<18>(conv_l2g_int.i_z).to_string();
-            bitString += std::bitset<8>(newModuleId).to_string();
+            bitString += std::bitset<9>(newModuleId).to_string();
             bitString += std::bitset<3>(chipId).to_string();
             bitStrings.push_back(bitString);
 
@@ -73,12 +73,18 @@ int LUTGenerator::makeLocalToGlobal() {
     for (unsigned i=0; i<bitStrings_breaks.size(); ++i) {
         // Open text file
         TString txtname = Form("lut_L2G_l%i.txt", i+5);
+        TString coename = Form("lut_L2G_l%i.coe", i+5);
         ofstream txtfile(txtname.Data());
+        ofstream coefile(coename.Data());
+        coefile<<"memory_initialization_radix=2;\n"<<"memory_initialization_vector=\n";
 
         // Write text file
         std::vector<std::string>::const_iterator it=bitStrings.begin()+(i == 0 ? 0 : bitStrings_breaks.at(i-1));
         for (; it!=bitStrings.begin() + bitStrings_breaks.at(i); ++it) {
             txtfile << *it << std::endl;
+            coefile << "111" << *it;
+            if (it != bitStrings.begin() + bitStrings_breaks.at(i) -1) coefile << ",\n";
+            else coefile << ";\n";
             if (verbose_ > 2) {
                 std::cout << *it << std::endl;
             }
@@ -86,6 +92,7 @@ int LUTGenerator::makeLocalToGlobal() {
 
         // Close text file
         txtfile.close();
+        coefile.close();
     }
 
     return 0;
@@ -133,7 +140,7 @@ int LUTGenerator::makeLocalToGlobalStar() {
             bitString += std::bitset<18>(conv_l2g_int.i_z).to_string();
             bitString += std::bitset<18>(conv_l2g_int.i_r0).to_string();
             bitString += std::bitset<18>(conv_l2g_int.i_r).to_string();
-            bitString += std::bitset<8>(newModuleId).to_string();
+            bitString += std::bitset<9>(newModuleId).to_string();
             bitString += std::bitset<3>(chipId).to_string();
             bitStrings.push_back(bitString);
 
@@ -145,12 +152,18 @@ int LUTGenerator::makeLocalToGlobalStar() {
     for (unsigned i=0; i<bitStrings_breaks.size(); ++i) {
         // Open text file
         TString txtname = Form("lut_L2GStar_l%i.txt", i+5);
+        TString coename = Form("lut_L2GStar_l%i.coe", i+5);
         ofstream txtfile(txtname.Data());
+        ofstream coefile(coename.Data());
+        coefile<<"memory_initialization_radix=2;\n"<<"memory_initialization_vector=\n";
 
         // Write text file
         std::vector<std::string>::const_iterator it=bitStrings.begin()+(i == 0 ? 0 : bitStrings_breaks.at(i-1));
         for (; it!=bitStrings.begin()+bitStrings_breaks.at(i); ++it) {
             txtfile << *it << std::endl;
+            coefile << "111" << *it;
+            if (it != bitStrings.begin() + bitStrings_breaks.at(i) -1) coefile << ",\n";
+            else coefile << ";\n";
             if (verbose_ > 2) {
                 std::cout << *it << std::endl;
             }
@@ -158,6 +171,7 @@ int LUTGenerator::makeLocalToGlobalStar() {
 
         // Close text file
         txtfile.close();
+        coefile.close();
     }
 
     return 0;

--- a/AMSimulation/src/PatternGenerator.cc
+++ b/AMSimulation/src/PatternGenerator.cc
@@ -149,6 +149,7 @@ int PatternGenerator::makePatterns(TString src) {
             Attributes * attr = ins.first->second;
             if (attr) {
                 ++ attr->n;
+                attr->id = ievt;
                 attr->invPt.fill(simChargeOverPt);
                 attr->cotTheta.fill(simCotTheta);
                 attr->phi.fill(simPhi);
@@ -336,9 +337,11 @@ int PatternGenerator::writePatternsEmu(TString out) {
         freq = patternBank_pairs_.at(ipatt).second;
         if (freq < (unsigned) po_.minFrequency)  // cut off
             break;
-   
-        outfile_txt<<freq;
+
         const pattern_type& patt = patternBank_pairs_.at(ipatt).first;
+        
+        if (po_.speedup<1) outfile_txt << patternAttributes_map_.at(patt)->id;
+        else if (po_.speedup==1) outfile_txt << freq;
         for (unsigned ilayer=0; ilayer<po_.nLayers; ++ilayer) {
             int phi_ss = patt.at(ilayer) % 512;
             int z_ss   = patt.at(ilayer) / 512;


### PR DESCRIPTION
This commit updated the module ID for the LUT. 
In the old version, the module ID was 4 bits (lad) + 4 bits (mod), as explained in https://github.com/sergojin/SLHCL1TrackTriggerSimulations/pull/8
Now it has been updated to 5 bits (mod) + 4 bits (lad). 

As a result, the LUT txt file _lut_L2GStar.txt_ was updated to 84-bit strings: 

| 83..66 | 66..48 | 47..30 | 29..12 | 11..3 | 2..0 |
| --- | --- | --- | --- | --- | --- |
| unsigned 18b | unsigned 18b | unsigned 18b | unsigned 18b | unsigned 9b | unsigned 3b |
| n_phi0 | n_phi | n_z0 | n_z | moduleId | chipId |

The LUT txt file _lut_L2GStar.txt_ was updated to 120-bit strings: 

| 119..102 | 101..84 | 83..66 | 65..48 | 47..30 | 29..12 | 11..3 | 2..0 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| signed 18b | signed 18b | signed 18b | signed 18b | signed 18b | signed 18b | unsigned 9b | unsigned 3b |
| n_phi0 | n_phi | n_z0 | n_z | n_r0 | n_r | moduleId | chipId |
