### PR TITLE
Add a stub deltaS filter

### DIFF
--- a/AMSimulation/bin/amsim.cc
+++ b/AMSimulation/bin/amsim.cc
@@ -103,6 +103,7 @@ int main(int argc, char **argv) {
         ("maxMisses"    , po::value<int>(&option.maxMisses)->default_value(0), "Specify max number of allowed misses")
         ("maxStubs"     , po::value<int>(&option.maxStubs)->default_value(4), "Specfiy max number of stubs per superstrip")
         ("maxRoads"     , po::value<int>(&option.maxRoads)->default_value(999999999), "Specfiy max number of roads per event")
+        ("stubDsFilter" , po::bool_switch(&option.stubDsFilter)->default_value(false), "require stubs to pass the stub pT (deltaS) cut (default: false)")
 
         // Only for matrix building
         ("view"         , po::value<std::string>(&option.view)->default_value("XYZ"), "Specify fit view (e.g. XYZ, XY, RZ)")

--- a/AMSimulation/interface/Helper.h
+++ b/AMSimulation/interface/Helper.h
@@ -66,6 +66,23 @@ inline unsigned compressLayer(const unsigned& lay) {
     return 255;
 }
 
+// Apply stub pT (DeltaS) cut
+inline bool stubDeltaSFilter(unsigned moduleId, float bend) {
+   unsigned lay = decodeLayer(moduleId); 
+   unsigned lad = decodeLadder(moduleId); 
+   float Barrel[6] = {1.5, 1.5, 2.5, 4, 5.5, 6.5};
+   float Endcap[5][15] = { 
+   {1.0, 1.0, 1.5, 2.0, 2.5, 2.5, 2.5, 3.0, 3.5, 4.5, 3.0, 3.5, 4.0, 4.5, 5.0},  //D1
+   {1.0, 1.0, 1.5, 2.0, 2.0, 2.5, 2.5, 2.5, 3.0, 4.0, 2.5, 3.0, 3.5, 4.0, 4.5},  //D2
+   {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.5, 2.5, 2.5, 3.5, 4.0, 2.5, 3.0, 3.5, 4.0},  //D3
+   {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.5, 2.5, 3.0, 3.5, 2.5, 2.5, 3.0, 3.5},  //D4
+   {1.0, 1.0, 1.0, 1.5, 1.5, 2.0, 2.0, 2.0, 2.5, 2.5, 3.0, 3.5, 2.5, 2.5, 3.0}}; //D5
+   if (lay>=5  && lay<11 && (fabs(bend)<=Barrel[lay-5])) return true; 
+   if (lay>=11 && lay<16 && (fabs(bend)<=Endcap[lay-11][lad])) return true;   
+   if (lay>=18 && lay<23 && (fabs(bend)<=Endcap[lay-18][lad])) return true;
+   return false; 
+} 
+
 }  // namespace slhcl1tt
 
 #endif

--- a/AMSimulation/interface/Helper.h
+++ b/AMSimulation/interface/Helper.h
@@ -70,8 +70,8 @@ inline unsigned compressLayer(const unsigned& lay) {
 inline bool stubDeltaSFilter(unsigned moduleId, float bend) {
    unsigned lay = decodeLayer(moduleId); 
    unsigned lad = decodeLadder(moduleId); 
-   float Barrel[6] = {1.5, 1.5, 2.5, 4, 5.5, 6.5};
-   float Endcap[5][15] = { 
+   static const float Barrel[6] = {1.5, 1.5, 2.5, 4, 5.5, 6.5};
+   static const float Endcap[5][15] = { 
    {1.0, 1.0, 1.5, 2.0, 2.5, 2.5, 2.5, 3.0, 3.5, 4.5, 3.0, 3.5, 4.0, 4.5, 5.0},  //D1
    {1.0, 1.0, 1.5, 2.0, 2.0, 2.5, 2.5, 2.5, 3.0, 4.0, 2.5, 3.0, 3.5, 4.0, 4.5},  //D2
    {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.5, 2.5, 2.5, 3.5, 4.0, 2.5, 3.0, 3.5, 4.0},  //D3

--- a/AMSimulation/interface/PatternMatcher.h
+++ b/AMSimulation/interface/PatternMatcher.h
@@ -18,7 +18,7 @@ class PatternMatcher {
     // Constructor
     PatternMatcher(const ProgramOption& po)
     : po_(po),
-      nEvents_(po.maxEvents), verbose_(po.verbose), removeOverlap_(po.removeOverlap),
+      nEvents_(po.maxEvents), verbose_(po.verbose), removeOverlap_(po.removeOverlap), stubDsFilter_(po.stubDsFilter), 
       prefixRoad_("AMTTRoads_"), suffix_("") {
 
         // Initialize
@@ -62,6 +62,7 @@ class PatternMatcher {
     long long nEvents_;
     int verbose_;
     bool removeOverlap_;
+    bool stubDsFilter_;
 
     // Configurations
     const TString prefixRoad_;

--- a/AMSimulation/interface/ProgramOption.h
+++ b/AMSimulation/interface/ProgramOption.h
@@ -62,6 +62,7 @@ struct ProgramOption {
 
     bool        no_trim;
     bool        removeOverlap;
+    bool        stubDsFilter;
 
     std::string datadir;
 };

--- a/AMSimulation/src/ProgramOption.cc
+++ b/AMSimulation/src/ProgramOption.cc
@@ -66,6 +66,7 @@ std::ostream& operator<<(std::ostream& o, const ProgramOption& po) {
 
       << "  no_trim: "      << po.no_trim
       << "  removeOverlap: "<< po.removeOverlap
+      << "  stubDsFilter: " << po.stubDsFilter
 
       << "  datadir: "      << po.datadir
       ;


### PR DESCRIPTION
This filter can only be enabled with option '--stubDsFilter' when doing pattern matching or producing data sourcing files. For example: 
amsim -R -i ~/Public/TTdemo_integration/MultiMuons_tt27_PU140_ntuple_10ev.root -o roads.root -b /eos/uscms/store/user/l1upgrades/SLHC/GEN/Demo_Emulator/patternBank_tt27_sf1_nz8_pt3_300M_emu.root -v 3 -s sf1_nz8 --emu 1 --maxMisses 1 --maxPatterns 6728700 --stubDsFilter

This filter is consistent with the new 3 GeV stub pT cut here:
https://github.com/cms-sw/cmssw/commit/f105a21118dfa72546e8c396255ce48077b546cf#diff-1a34e386df7014b06161548fd3f131ac
